### PR TITLE
Use commonjs dist file as export for "require"

### DIFF
--- a/packages/route/package.json
+++ b/packages/route/package.json
@@ -28,7 +28,7 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.mjs"
+      "require": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
This fixes error `SyntaxError: Cannot use import statement outside a module` when trying to use @webroute/route in a CommonJS context.

I didn't check to see if this affects other packages in the repo as well.